### PR TITLE
Package id fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Twilio Client Phonegap plugins for iOS and Android (version 1.0.7)
+# Twilio Client Phonegap plugins for iOS and Android (version 1.1.0)
 
 These are Phonegap plugins that expose the same JS API as Twilio Client for web as much as possible, meaning you should be able to use the same Twilio Client code from your web application inside of your Phonegap application with few if any modifications. 
 
 # Latest versions tested with this plugin
-#### (as of August 16, 2016)
-- Cordova 6.3.1
+#### (as of July 14, 2017)
+- Cordova 7.0.1
 - Cordova Android 5.2.1
-- Cordova iOS 4.1.0
-- Twilio Client for iOS 1.2.8
+- Cordova iOS 4.3.1
+- Twilio Client for iOS 1.2.7
 - Twilio Client for Android 1.2.17
-- XCode 7.3
+- XCode 8.3
 - Android SDK 23
 
 # Android Gradle Support
@@ -27,35 +27,11 @@ https://github.com/jefflinwood/TwilioClientPhoneGapExampleApp
 
 # PhoneGap/Cordova Overview
 
-- Install the most recent version of Cordova (as of this writing, 6.3.1 tools  - http://http://cordova.apache.org/ 
-- Install plugman - https://github.com/apache/cordova-plugman
+- Install the most recent version of Cordova (as of this writing, 7.0.1 tools  - http://http://cordova.apache.org/ 
 
-# Both Platforms at once
-
-##Instructions
+# Installation Instructions
 ```
-cordova plugin add  https://github.com/jefflinwood/twilio_client_phonegap.git
-```
-
-# iOS only
-
-##Instructions
-
-```
- plugman install --platform ios --project platforms/ios --plugin https://github.com/jefflinwood/twilio_client_phonegap.git
-
-```
-
-
-- After installing the Twilio Client plugin, you will need to download and install the Twilio Client SDK for iOS - follow the directions provided after plugman finishes.
-
-# Android only
-
-## Instructions
-
-```
-plugman install --platform android --project platforms/android --plugin https://github.com/jefflinwood/twilio_client_phonegap.git
-
+cordova plugin add twilio-client-phonegap-plugin
 ```
 
 ## Additional Features
@@ -77,10 +53,14 @@ Twilio.Connection.setSpeaker("on");
 ```
 
 ## Changelog
+- 1.1.0 - Utilize Cocoapods framework support for iOS
 - 1.0.7 - Added Marshmallow/SDK 23 support for runtime permissions
 - 1.0.6 - Updated Android platform for plugin to pull in Twilio Android SDK using Gradle
 
 ## Limitations
+
+The current version of the Twilio Client SDK requires iOS 8.1, but the Cocoapods support in Cordova iOS is 
+hardcoded to iOS 8.0. Will need to get this addressed in the cordova-ios project.
 
 This is plugin is a first cut and should be considered alpha. Please use it and break it :) Report any issues using the Github issue tracker.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twilio Client Phonegap plugins for iOS and Android (version 1.1.0)
+# Twilio Client Phonegap plugins for iOS and Android (version 1.1.1)
 
 These are Phonegap plugins that expose the same JS API as Twilio Client for web as much as possible, meaning you should be able to use the same Twilio Client code from your web application inside of your Phonegap application with few if any modifications. 
 
@@ -53,6 +53,7 @@ Twilio.Connection.setSpeaker("on");
 ```
 
 ## Changelog
+- 1.1.1 - Fixed Twilio Connection disconnect argument in Javascript file.
 - 1.1.0 - Utilize Cocoapods framework support for iOS
 - 1.0.7 - Added Marshmallow/SDK 23 support for runtime permissions
 - 1.0.6 - Updated Android platform for plugin to pull in Twilio Android SDK using Gradle

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "twilio-client-phonegap-plugin",
+  "version": "1.1.0",
+  "description": "Use the Twilio Client SDK for iOS or Android VoIP support with Cordova/PhoneGap.",
+  "cordova": {
+    "id": "com.phonegap.plugins.twilioclient",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jefflinwood/twilio_client_phonegap.git"
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=6.4.0"
+    },
+    {
+      "name": "cordova-android",
+      "version": ">=6.0.0"
+    },
+    {
+      "name": "cordova-ios",
+      "version": ">=4.3.0"
+    }
+  ],
+  "author": "Stevie Graham/Lyle Pratt/Jeff Linwood",
+  "license": "Apache",
+  "bugs": {
+    "url": "https://github.com/jefflinwood/twilio_client_phonegap/issues"
+  },
+  "homepage": "https://github.com/jefflinwood/twilio_client_phonegap#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-client-phonegap-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Use the Twilio Client SDK for iOS or Android VoIP support with Cordova/PhoneGap.",
   "cordova": {
     "id": "com.phonegap.plugins.twilioclient",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.phonegap.plugins.twilioclient"
-    version="1.0.7">
+    version="1.1.0">
 
     <name>TwilioClient</name>
     <description>Use the native Twilio Client for iOS or Android with Cordova/PhoneGap and the Twilio Client JavaScript API</description>
@@ -50,6 +50,9 @@
           </feature>
         </config-file>
 
+        <framework src="TwilioSDK" type="podspec" spec="=1.2.7" />
+
+
         <!-- Add support for background VOIP and audio to the plist -->
         <config-file target="*-Info.plist" parent="UIBackgroundModes">
             <array>
@@ -66,13 +69,5 @@
 
         <header-file src="src/ios/TCPlugin.h" />
         <source-file src="src/ios/TCPlugin.m" />
-
-        <info>
-You need to download __Twilio Client for iOS__ from https://www.twilio.com/docs/client/ios. Uncompress the download - you will need to follow a few steps that plugman can not do yet:
-
-* Add the Twilio Client static libraries (the .a files in the Libraries folder) to your Xcode project
-
-* Add the Twilio Client headers files (the .h files in the Headers folder) to your Xcode project
-        </info>
     </platform>
 </plugin>

--- a/www/tcPlugin.js
+++ b/www/tcPlugin.js
@@ -107,7 +107,7 @@
         Cordova.exec(null,null,"TCPlugin","rejectConnection",[]);
     }
 
-    TwilioPlugin.Connection.prototype.disconnect = function(fn) {
+    TwilioPlugin.Connection.prototype.disconnect = function(argument) {
         if (typeof(argument) == 'function') {
             delegate['onconnectiondisconnect'] = argument;
         } else {


### PR DESCRIPTION
The package ID com.phonegap.plugins.twilioclient is not found on npm. Changed to twilio-client-phonegap-plugin to match the plugin at https://www.npmjs.com/package/twilio-voice-phonegap-plugin

